### PR TITLE
HTTPS-ify index.html links

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Flight by Twitter</title>
     <meta name="description" content="A lightweight, component-based JavaScript framework for assigning behavior to DOM nodes.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" type="image/x-icon" href="http://twitter.com/favicons/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="https://twitter.com/favicons/favicon.ico">
     <link rel="stylesheet" href="css/normalize.min.css">
     <link rel="stylesheet" href="css/main.css">
   </head>
@@ -33,8 +33,8 @@
 
       <div class="site-main" role="main">
         <h2>Overview</h2>
-        <p>Flight is a lightweight, component-based JavaScript framework that maps behavior to DOM nodes. Twitter uses it for their web applications. By way of example, we've included a <a href="http://flightjs.github.io/example-app/">simple email client demo</a> (browse the <a href="https://github.com/flightjs/example-app">source</a>) built over the Flight framework. There's also a flight implementation over on the <a href="http://todomvc.com/dependency-examples/flight/">todoMVC</a> site (<a href="https://github.com/tastejs/todomvc/tree/gh-pages/dependency-examples/flight">source</a>), courtesy of <a href="https://github.com/mkuklis">@mkuklis</a></p>
-        <p>Flight uses <a href="http://jquery.com/">jQuery</a> and requires a module loader with support for AMD, like <a href="http://webpack.github.io/">WebPack</a> or <a href="http://requirejs.org/">Require.js</a>. Please read the <a href="https://github.com/flightjs/flight/blob/master/README.md">Flight documentation</a> for installation instructions.</p>
+        <p>Flight is a lightweight, component-based JavaScript framework that maps behavior to DOM nodes. Twitter uses it for their web applications. By way of example, we've included a <a href="https://flightjs.github.io/example-app/">simple email client demo</a> (browse the <a href="https://github.com/flightjs/example-app">source</a>) built over the Flight framework. There's also a flight implementation over on the <a href="http://todomvc.com/dependency-examples/flight/">todoMVC</a> site (<a href="https://github.com/tastejs/todomvc/tree/gh-pages/dependency-examples/flight">source</a>), courtesy of <a href="https://github.com/mkuklis">@mkuklis</a></p>
+        <p>Flight uses <a href="https://jquery.com/">jQuery</a> and requires a module loader with support for AMD, like <a href="http://webpack.github.io/">WebPack</a> or <a href="http://requirejs.org/">Require.js</a>. Please read the <a href="https://github.com/flightjs/flight/blob/master/README.md">Flight documentation</a> for installation instructions.</p>
 
         You will have to include jQuery and use a module loader with support for AMD, like Webpack or Require.js
 
@@ -92,6 +92,6 @@
 
     </div><!-- /.container -->
 
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="http://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </body>
 </html>


### PR DESCRIPTION
https://flightjs.github.io/ is accessible via TLS, but linked to the Twitter Widgets script via HTTP causing a mixed content warning
