### PR TITLE
change documentation links to point at 1.x docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <div class="site-main" role="main">
         <h2>Overview</h2>
         <p>Flight is a lightweight, component-based JavaScript framework that maps behavior to DOM nodes. Twitter uses it for their web applications. By way of example, we've included a <a href="https://flightjs.github.io/example-app/">simple email client demo</a> (browse the <a href="https://github.com/flightjs/example-app">source</a>) built over the Flight framework. There's also a flight implementation over on the <a href="http://todomvc.com/examples/flight/">todoMVC</a> site (<a href="https://github.com/tastejs/todomvc/tree/gh-pages/examples/flight">source</a>), courtesy of <a href="https://github.com/mkuklis">@mkuklis</a></p>
-        <p>Flight uses <a href="https://jquery.com/">jQuery</a> and requires a module loader with support for AMD, like <a href="http://webpack.github.io/">WebPack</a> or <a href="http://requirejs.org/">Require.js</a>. Please read the <a href="https://github.com/flightjs/flight/blob/master/README.md">Flight documentation</a> for installation instructions.</p>
+        <p>Flight uses <a href="https://jquery.com/">jQuery</a> and requires a module loader with support for AMD, like <a href="http://webpack.github.io/">WebPack</a> or <a href="http://requirejs.org/">Require.js</a>. Please read the <a href="https://github.com/flightjs/flight/tree/v1.x">Flight documentation</a> for installation instructions.</p>
 
         <h2>Why Flight?</h2>
         <p>Flight is distinct from existing frameworks in that it doesn't prescribe or provide any particular approach to rendering or providing data to a web application. It's agnostic to how requests are routed, which templating language you use or even if you render your HTML on the client or the server. While some web frameworks encourage developers to arrange their code around a prescribed model layer, Flight is organized around the existing DOM model with functionality mapped directly to DOM nodes.</p>
@@ -61,7 +61,7 @@
         <p>A mixin defines a set of functionality that is useful to more than one object. Flight comes with built-in support for <a href="http://javascriptweblog.wordpress.com/2011/05/31/a-fresh-look-at-javascript-mixins/">functional mixins</a>, including protection against unintentional overrides and duplicate mixins. While classical JavaScript patterns support only single inheritance, a component (or other object) can have multiple mixins applied to it. Moreover mixins requires a fraction of the boilerplate required to form traditional classical hierarchies out of constructor-prototypes hybrids, and don't suffer the leaky abstractions of the latter ('super', 'static', 'const' etc.)</p>
 
         <h2>Documentation and Demo</h2>
-        <p>The project includes <a href="https://github.com/flightjs/flight/blob/master/README.md">full documentation</a> as well as an <a href="https://github.com/flightjs/example-app">example app</a> in the form of an <a href="https://flightjs.github.io/example-app">email client</a>:</p>
+        <p>The project includes <a href="https://github.com/flightjs/flight/tree/master/doc">full documentation</a> as well as an <a href="https://github.com/flightjs/example-app">example app</a> in the form of an <a href="https://flightjs.github.io/example-app">email client</a>:</p>
 
         <p><img src="img/demo.png" alt=""></p>
 


### PR DESCRIPTION
Saw this issue open in the main flightjs repo with the help wanted tag. https://github.com/flightjs/flight/issues/360